### PR TITLE
Ability to execute plugin on remote slaves

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jvctg/config/ViolationConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctg/config/ViolationConfig.java
@@ -2,7 +2,11 @@ package org.jenkinsci.plugins.jvctg.config;
 
 import se.bjurr.violations.lib.reports.Reporter;
 
-public class ViolationConfig {
+import java.io.Serializable;
+
+public class ViolationConfig implements Serializable {
+ private static final long serialVersionUID = 9009372864417543781L;
+
  private Reporter reporter;
  private String pattern;
 

--- a/src/main/java/org/jenkinsci/plugins/jvctg/config/ViolationsToGitHubConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctg/config/ViolationsToGitHubConfig.java
@@ -2,9 +2,12 @@ package org.jenkinsci.plugins.jvctg.config;
 
 import static com.google.common.collect.Lists.newArrayList;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class ViolationsToGitHubConfig {
+public class ViolationsToGitHubConfig implements Serializable {
+ private static final long serialVersionUID = 4851568645021422528L;
+
  private List<ViolationConfig> violationConfigs = newArrayList();
  private boolean createSingleFileComments;
  private boolean createCommentWithAllSingleFileComments;

--- a/src/main/java/org/jenkinsci/plugins/jvctg/perform/JvctsPerformer.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctg/perform/JvctsPerformer.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.util.List;
 
 import org.jenkinsci.plugins.jvctg.config.ViolationConfig;
@@ -57,8 +58,14 @@ public class JvctsPerformer {
    listener.getLogger().println("Running Jenkins Violation Comments To GitHub");
    listener.getLogger().println("Will comment " + configExpanded.getPullRequestId());
 
-   File workspace = new File(build.getExecutor().getCurrentWorkspace().toURI());
-   FilePath fp = new FilePath(workspace);
+   FilePath workspace = build.getExecutor().getCurrentWorkspace();
+   URI workspacePath = build.getExecutor().getCurrentWorkspace().toURI();
+   FilePath fp;
+   if(workspace.isRemote()) {
+    fp = new FilePath(workspace.getChannel(), workspacePath.getPath());
+   } else {
+    fp = new FilePath(new File(workspacePath));
+   }
    fp.act(new FileCallable<Void>() {
 
     private static final long serialVersionUID = 6166111757469534436L;


### PR DESCRIPTION
Accessing files on remote slaves requires one level of indirection by
using workspace.channel(). Also, all the configurations needs to be
serializable for this to work.

Here is an example of an error seen prior to this patch
```
SEVERE: 
java.lang.RuntimeException: /home/jenkins/workspace/non-std-defn/ghe-merge-test not found
        at se.bjurr.violations.lib.ViolationsReporterApi.inFolder(ViolationsReporterApi.java:40)
        at org.jenkinsci.plugins.jvctg.perform.JvctsPerformer.doPerform(JvctsPerformer.java:121)
        at org.jenkinsci.plugins.jvctg.perform.JvctsPerformer$1.invoke(JvctsPerformer.java:70)
        at org.jenkinsci.plugins.jvctg.perform.JvctsPerformer$1.invoke(JvctsPerformer.java:62)
        at hudson.FilePath.act(FilePath.java:990)
        at hudson.FilePath.act(FilePath.java:968)
        at org.jenkinsci.plugins.jvctg.perform.JvctsPerformer.jvctsPerform(JvctsPerformer.java:62)
        at org.jenkinsci.plugins.jvctg.ViolationsToGitHubRecorder.perform(ViolationsToGitHubRecorder.java:27)
        at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
        at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:782)
        at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:723)
        at hudson.model.Build$BuildExecution.post2(Build.java:185)
        at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:668)
        at hudson.model.Run.execute(Run.java:1763)
        at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
        at hudson.model.ResourceController.execute(ResourceController.java:98)
        at hudson.model.Executor.run(Executor.java:410)
```