### PR TITLE
Various changes to support use of plugin within Jenkins workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,56 @@ The pull request will be commented like this.
 
 ![Pull request comment](https://github.com/jenkinsci/violation-comments-to-github-jenkins-plugin/blob/master/sandbox/github-pr-diff-comment.png)
 
+# Use in workflow
+
+This plugin can participate in a Jenkins workflow. For example, a Jenkinsfile like:
+
+```
+
+    import org.jenkinsci.plugins.jvctg.config.ViolationConfig;
+    import se.bjurr.violations.lib.reports.Reporter;
+
+    node {
+  
+  	stage name:"Checkout";    
+    checkout scm;
+  
+    sh 'git rev-parse HEAD > status'
+    commit = readFile('status').trim()
+  
+    // figure out the branch name
+    def jobName = "${env.JOB_NAME}"
+    def idx = jobName.lastIndexOf('/');
+    branch = jobName.substring(idx+1);
+    // Un-remove the / to - conversion.
+    branch = branch.replace("-","/");
+    branch = branch.replace("%2F","/");
+  
+    theJob = jobName.replace("/", " ");
+  
+    echo "Build of ${env.JOB_NAME} #${env.BUILD_NUMBER} : ${commit} on ${branch}";
+  
+    int pr = 0;
+    if( branch.startsWith("PR/") ) {
+    	pr = Integer.parseInt(branch.substring(3));
+  
+    	echo "This is PR ${pr}";
+
+        // Update comments         
+        def configs = [
+                new ViolationConfig(Reporter.FINDBUGS, ".*/findbugs.*\\.xml\$")
+                ];
+            
+            step([$class: 'ViolationsToGitHubRecorder', 
+        		repositoryOwner: 'AllocateSoftware',
+            	repositoryName: 'experiment',
+            	createSingleFileComments: true,
+            	pullRequestId: "${pr}",
+            violationConfigs: configs]);
+    }
+   }
+```
+
 
 # Plugin development
 More details on Jenkins plugin development is available [here](https://wiki.jenkins-ci.org/display/JENKINS/Plugin+tutorial).

--- a/src/main/java/org/jenkinsci/plugins/jvctg/ViolationsToGitHubConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctg/ViolationsToGitHubConfiguration.java
@@ -1,0 +1,85 @@
+package org.jenkinsci.plugins.jvctg;
+
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ * Created by magnayn on 07/04/2016.
+ */
+@Extension
+public class ViolationsToGitHubConfiguration extends GlobalConfiguration {
+
+
+    public String username;
+    public String password;
+    public String oAuth2Token;
+    public String gitHubUrl;
+    public String repositoryOwner;
+
+    /**
+     * Returns this singleton instance.
+     *
+     * @return the singleton.
+     */
+    public static ViolationsToGitHubConfiguration get() {
+        return GlobalConfiguration.all().get(ViolationsToGitHubConfiguration.class);
+    }
+
+    public ViolationsToGitHubConfiguration() {
+        load();
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        req.bindJSON(this, json);
+        return true;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    @DataBoundSetter
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    @DataBoundSetter
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getoAuth2Token() {
+        return oAuth2Token;
+    }
+
+    @DataBoundSetter
+    public void setoAuth2Token(String oAuth2Token) {
+        this.oAuth2Token = oAuth2Token;
+    }
+
+    public String getGitHubUrl() {
+        return gitHubUrl;
+    }
+
+    @DataBoundSetter
+    public void setGitHubUrl(String gitHubUrl) {
+        this.gitHubUrl = gitHubUrl;
+    }
+
+    public String getRepositoryOwner() {
+        return repositoryOwner;
+    }
+
+    @DataBoundSetter
+    public void setRepositoryOwner(String repositoryOwner) {
+        this.repositoryOwner = repositoryOwner;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/jvctg/ViolationsToGitHubConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctg/ViolationsToGitHubConfiguration.java
@@ -6,11 +6,13 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import java.io.Serializable;
+
 /**
  * Created by magnayn on 07/04/2016.
  */
 @Extension
-public class ViolationsToGitHubConfiguration extends GlobalConfiguration {
+public class ViolationsToGitHubConfiguration extends GlobalConfiguration implements Serializable {
 
 
     public String username;
@@ -35,6 +37,7 @@ public class ViolationsToGitHubConfiguration extends GlobalConfiguration {
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
         req.bindJSON(this, json);
+        save();
         return true;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/jvctg/ViolationsToGitHubRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctg/ViolationsToGitHubRecorder.java
@@ -4,9 +4,12 @@ import static hudson.tasks.BuildStepMonitor.NONE;
 import static java.lang.Boolean.TRUE;
 import static org.jenkinsci.plugins.jvctg.perform.JvctsPerformer.jvctsPerform;
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
@@ -14,18 +17,20 @@ import hudson.tasks.Recorder;
 
 import java.io.IOException;
 
+import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.plugins.jvctg.config.ViolationsToGitHubConfig;
 
-public class ViolationsToGitHubRecorder extends Recorder {
+import javax.annotation.Nonnull;
+
+public class ViolationsToGitHubRecorder extends Recorder implements SimpleBuildStep {
  @Extension
  public static final BuildStepDescriptor<Publisher> DESCRIPTOR = new ViolationsToGitHubDescriptor();
  private ViolationsToGitHubConfig config;
 
  @Override
- public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+ public void perform(@Nonnull Run<?, ?> build, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
    throws InterruptedException, IOException {
   jvctsPerform(config, build, listener);
-  return TRUE;
  }
 
  @Override

--- a/src/main/java/org/jenkinsci/plugins/jvctg/ViolationsToGitHubRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctg/ViolationsToGitHubRecorder.java
@@ -17,9 +17,12 @@ import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 
 import java.io.IOException;
+import java.util.List;
 
 import jenkins.tasks.SimpleBuildStep;
+import org.jenkinsci.plugins.jvctg.config.ViolationConfig;
 import org.jenkinsci.plugins.jvctg.config.ViolationsToGitHubConfig;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
 
@@ -37,7 +40,7 @@ public class ViolationsToGitHubRecorder extends Recorder implements SimpleBuildS
 
   combinedConfig.applyDefaults(defaults);
 
-  jvctsPerform(combinedConfig, build, listener);
+  jvctsPerform(combinedConfig, filePath, build, listener);
  }
 
  @Override
@@ -45,8 +48,28 @@ public class ViolationsToGitHubRecorder extends Recorder implements SimpleBuildS
   return DESCRIPTOR;
  }
 
+
  public ViolationsToGitHubRecorder() {
  }
+
+ @DataBoundConstructor
+  public ViolationsToGitHubRecorder( boolean createSingleFileComments, boolean createCommentWithAllSingleFileComments, String repositoryName, String repositoryOwner, String password, String username, String oAuth2Token, String pullRequestId, String gitHubUrl, boolean commentOnlyChangedContent, List<
+    ViolationConfig > violationConfigs) {
+
+   config = new ViolationsToGitHubConfig(
+    createSingleFileComments ,
+    createCommentWithAllSingleFileComments ,
+    repositoryName ,
+    repositoryOwner ,
+    password ,
+    username ,
+    oAuth2Token ,
+    pullRequestId ,
+    gitHubUrl ,
+    commentOnlyChangedContent, violationConfigs);
+  }
+
+
 
  @Override
  public BuildStepMonitor getRequiredMonitorService() {

--- a/src/main/java/org/jenkinsci/plugins/jvctg/ViolationsToGitHubRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctg/ViolationsToGitHubRecorder.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.jvctg;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static hudson.tasks.BuildStepMonitor.NONE;
 import static java.lang.Boolean.TRUE;
 import static org.jenkinsci.plugins.jvctg.perform.JvctsPerformer.jvctsPerform;
@@ -30,7 +31,13 @@ public class ViolationsToGitHubRecorder extends Recorder implements SimpleBuildS
  @Override
  public void perform(@Nonnull Run<?, ?> build, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
    throws InterruptedException, IOException {
-  jvctsPerform(config, build, listener);
+
+  ViolationsToGitHubConfig combinedConfig = new ViolationsToGitHubConfig(config);
+  ViolationsToGitHubConfiguration defaults = ViolationsToGitHubConfiguration.get();
+
+  combinedConfig.applyDefaults(defaults);
+
+  jvctsPerform(combinedConfig, build, listener);
  }
 
  @Override
@@ -53,4 +60,5 @@ public class ViolationsToGitHubRecorder extends Recorder implements SimpleBuildS
  public ViolationsToGitHubConfig getConfig() {
   return config;
  }
+
 }

--- a/src/main/java/org/jenkinsci/plugins/jvctg/config/ViolationsToGitHubConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctg/config/ViolationsToGitHubConfig.java
@@ -41,6 +41,21 @@ public class ViolationsToGitHubConfig implements Serializable {
   this.commentOnlyChangedContent = rhs.commentOnlyChangedContent;
  }
 
+
+ public ViolationsToGitHubConfig( boolean createSingleFileComments, boolean createCommentWithAllSingleFileComments, String repositoryName, String repositoryOwner, String password, String username, String oAuth2Token, String pullRequestId, String gitHubUrl, boolean commentOnlyChangedContent, List<ViolationConfig> violationConfigs) {
+  this.violationConfigs = violationConfigs;
+  this.createSingleFileComments = createSingleFileComments;
+  this.createCommentWithAllSingleFileComments = createCommentWithAllSingleFileComments;
+  this.repositoryName = repositoryName;
+  this.repositoryOwner = repositoryOwner;
+  this.password = password;
+  this.username = username;
+  this.oAuth2Token = oAuth2Token;
+  this.pullRequestId = pullRequestId;
+  this.gitHubUrl = gitHubUrl;
+  this.commentOnlyChangedContent = commentOnlyChangedContent;
+ }
+
  public String getOAuth2Token() {
   return oAuth2Token;
  }

--- a/src/main/java/org/jenkinsci/plugins/jvctg/config/ViolationsToGitHubConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctg/config/ViolationsToGitHubConfig.java
@@ -1,5 +1,8 @@
 package org.jenkinsci.plugins.jvctg.config;
 
+import org.jenkinsci.plugins.jvctg.ViolationsToGitHubConfiguration;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Lists.newArrayList;
 
 import java.io.Serializable;
@@ -22,6 +25,20 @@ public class ViolationsToGitHubConfig implements Serializable {
 
  public ViolationsToGitHubConfig() {
 
+ }
+
+ public ViolationsToGitHubConfig(ViolationsToGitHubConfig rhs) {
+  this.violationConfigs = rhs.violationConfigs;
+  this.createSingleFileComments = rhs.createSingleFileComments;
+  this.createCommentWithAllSingleFileComments = rhs.createCommentWithAllSingleFileComments;
+  this.repositoryName = rhs.repositoryName;
+  this.repositoryOwner = rhs.repositoryOwner;
+  this.password = rhs.password;
+  this.username = rhs.username;
+  this.oAuth2Token = rhs.oAuth2Token;
+  this.pullRequestId = rhs.pullRequestId;
+  this.gitHubUrl = rhs.gitHubUrl;
+  this.commentOnlyChangedContent = rhs.commentOnlyChangedContent;
  }
 
  public String getOAuth2Token() {
@@ -110,5 +127,23 @@ public class ViolationsToGitHubConfig implements Serializable {
 
  public void setCommentOnlyChangedContent(boolean commentOnlyChangedContent) {
   this.commentOnlyChangedContent = commentOnlyChangedContent;
+ }
+
+ public void applyDefaults(ViolationsToGitHubConfiguration defaults) {
+  if( isNullOrEmpty(gitHubUrl) ) {
+   gitHubUrl = defaults.getGitHubUrl();
+  }
+  if( isNullOrEmpty(username) ) {
+   username = defaults.getUsername();
+  }
+  if( isNullOrEmpty(password) ) {
+   password = defaults.getPassword();
+  }
+  if( isNullOrEmpty(repositoryOwner) ) {
+   repositoryOwner = defaults.getRepositoryOwner();
+  }
+  if( isNullOrEmpty(oAuth2Token) ) {
+   oAuth2Token = defaults.getoAuth2Token() ;
+  }
  }
 }

--- a/src/main/java/org/jenkinsci/plugins/jvctg/config/ViolationsToGitHubConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctg/config/ViolationsToGitHubConfig.java
@@ -146,7 +146,11 @@ public class ViolationsToGitHubConfig implements Serializable {
 
  public void applyDefaults(ViolationsToGitHubConfiguration defaults) {
   if( isNullOrEmpty(gitHubUrl) ) {
-   gitHubUrl = defaults.getGitHubUrl();
+   String rhs = defaults.getGitHubUrl();
+   if( isNullOrEmpty(rhs) ) {
+    rhs = "https://api.github.com/";
+   }
+   gitHubUrl = rhs;
   }
   if( isNullOrEmpty(username) ) {
    username = defaults.getUsername();

--- a/src/main/java/org/jenkinsci/plugins/jvctg/perform/JvctsPerformer.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctg/perform/JvctsPerformer.java
@@ -25,6 +25,8 @@ import hudson.FilePath;
 import hudson.FilePath.FileCallable;
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
 
 import java.io.File;
@@ -45,8 +47,8 @@ import com.google.common.io.CharStreams;
 
 public class JvctsPerformer {
 
- public static void jvctsPerform(final ViolationsToGitHubConfig configUnexpanded, AbstractBuild<?, ?> build,
-   final BuildListener listener) {
+ public static void jvctsPerform(final ViolationsToGitHubConfig configUnexpanded, Run<?, ?> build,
+                                 final TaskListener listener) {
   try {
    EnvVars env = build.getEnvironment(listener);
    final ViolationsToGitHubConfig configExpanded = expand(configUnexpanded, env);
@@ -100,7 +102,7 @@ public class JvctsPerformer {
  }
 
  @VisibleForTesting
- public static void doPerform(ViolationsToGitHubConfig config, File workspace, BuildListener listener)
+ public static void doPerform(ViolationsToGitHubConfig config, File workspace, TaskListener listener)
    throws MalformedURLException {
   if (isNullOrEmpty(config.getPullRequestId())) {
    doLog(INFO, "No pull request id defined, will not send violation comments to GitHub.");
@@ -175,7 +177,7 @@ public class JvctsPerformer {
   return expanded;
  }
 
- private static void logConfiguration(ViolationsToGitHubConfig config, AbstractBuild<?, ?> build, BuildListener listener) {
+ private static void logConfiguration(ViolationsToGitHubConfig config, Run<?, ?> build, TaskListener listener) {
   listener.getLogger().println(FIELD_GITHUBURL + ": " + config.getGitHubUrl());
   listener.getLogger().println(FIELD_REPOSITORYOWNER + ": " + config.getRepositoryOwner());
   listener.getLogger().println(FIELD_REPOSITORYNAME + ": " + config.getRepositoryName());

--- a/src/main/java/org/jenkinsci/plugins/jvctg/perform/JvctsPerformer.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctg/perform/JvctsPerformer.java
@@ -47,7 +47,7 @@ import com.google.common.io.CharStreams;
 
 public class JvctsPerformer {
 
- public static void jvctsPerform(final ViolationsToGitHubConfig configUnexpanded, Run<?, ?> build,
+ public static void jvctsPerform(final ViolationsToGitHubConfig configUnexpanded, FilePath fp, Run<?, ?> build,
                                  final TaskListener listener) {
   try {
    EnvVars env = build.getEnvironment(listener);
@@ -60,14 +60,7 @@ public class JvctsPerformer {
    listener.getLogger().println("Running Jenkins Violation Comments To GitHub");
    listener.getLogger().println("Will comment " + configExpanded.getPullRequestId());
 
-   FilePath workspace = build.getExecutor().getCurrentWorkspace();
-   URI workspacePath = build.getExecutor().getCurrentWorkspace().toURI();
-   FilePath fp;
-   if (workspace.isRemote()) {
-    fp = new FilePath(workspace.getChannel(), workspacePath.getPath());
-   } else {
-    fp = new FilePath(new File(workspacePath));
-   }
+
    fp.act(new FileCallable<Void>() {
 
     private static final long serialVersionUID = 6166111757469534436L;
@@ -183,9 +176,9 @@ public class JvctsPerformer {
   listener.getLogger().println(FIELD_REPOSITORYNAME + ": " + config.getRepositoryName());
   listener.getLogger().println(FIELD_PULLREQUESTID + ": " + config.getPullRequestId());
 
-  listener.getLogger().println(FIELD_USERNAME + ": " + !config.getUsername().isEmpty());
-  listener.getLogger().println(FIELD_PASSWORD + ": " + !config.getPassword().isEmpty());
-  listener.getLogger().println(FIELD_OAUTH2TOKEN + ": " + !config.getOAuth2Token().isEmpty());
+  listener.getLogger().println(FIELD_USERNAME + ": " + !isNullOrEmpty(config.getUsername()));
+  listener.getLogger().println(FIELD_PASSWORD + ": " + !isNullOrEmpty(config.getPassword()));
+  listener.getLogger().println(FIELD_OAUTH2TOKEN + ": " + !isNullOrEmpty(config.getOAuth2Token()));
 
   listener.getLogger().println(FIELD_CREATESINGLEFILECOMMENTS + ": " + config.getCreateSingleFileComments());
   listener.getLogger().println(

--- a/src/main/resources/org/jenkinsci/plugins/jvctg/ViolationsToGitHubConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/jvctg/ViolationsToGitHubConfiguration/config.jelly
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:d="jelly:define"
+         xmlns:f="/lib/form"
+         xmlns:l="/lib/layout"
+         xmlns:st="jelly:stapler"
+         xmlns:t="/lib/hudson">
+
+    <f:section title="GitHub Violations Server Defaults">
+
+        <f:entry title="User (Optional, you may also use OAuth2 token)">
+            <f:textbox name="username" value="${username}" />
+        </f:entry>
+
+        <f:entry title="Password (Optional, you may also use OAuth2 token)">
+            <f:password name="password" value="${password}" />
+        </f:entry>
+
+        <f:entry title="OAuth2 token (Optional, you may also use username and password)">
+            <f:password name="oAuth2Token" value="${oAuth2Token}" />
+        </f:entry>
+
+        <f:entry title="Base URL (Default is: https://api.github.com/)">
+            <f:textbox name="gitHubUrl" value="${gitHubUrl}" />
+        </f:entry>
+
+        <f:entry title="Repository owner (Like 'a' if repo is: https://github.com/a/b)">
+            <f:textbox name="repositoryOwner" value="${repositoryOwner}" />
+        </f:entry>
+
+    </f:section>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/jvctg/ViolationsToGitHubConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/jvctg/ViolationsToGitHubConfiguration/config.jelly
@@ -9,24 +9,24 @@
 
     <f:section title="GitHub Violations Server Defaults">
 
-        <f:entry title="User (Optional, you may also use OAuth2 token)">
-            <f:textbox name="username" value="${username}" />
+        <f:entry title="User (Optional, you may also use OAuth2 token)" field="username">
+            <f:textbox />
         </f:entry>
 
-        <f:entry title="Password (Optional, you may also use OAuth2 token)">
-            <f:password name="password" value="${password}" />
+        <f:entry title="Password (Optional, you may also use OAuth2 token)" field="password">
+            <f:password />
         </f:entry>
 
-        <f:entry title="OAuth2 token (Optional, you may also use username and password)">
-            <f:password name="oAuth2Token" value="${oAuth2Token}" />
+        <f:entry title="OAuth2 token (Optional, you may also use username and password)" field="oAuth2Token">
+            <f:password />
         </f:entry>
 
-        <f:entry title="Base URL (Default is: https://api.github.com/)">
-            <f:textbox name="gitHubUrl" value="${gitHubUrl}" />
+        <f:entry title="Base URL (Default is: https://api.github.com/)" field="gitHubUrl">
+            <f:textbox  value="${gitHubUrl}" />
         </f:entry>
 
-        <f:entry title="Repository owner (Like 'a' if repo is: https://github.com/a/b)">
-            <f:textbox name="repositoryOwner" value="${repositoryOwner}" />
+        <f:entry title="Repository owner (Like 'a' if repo is: https://github.com/a/b)" field="repositoryOwner">
+            <f:textbox />
         </f:entry>
 
     </f:section>

--- a/src/main/resources/org/jenkinsci/plugins/jvctg/ViolationsToGitHubConfiguration/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/jvctg/ViolationsToGitHubConfiguration/help.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    See <a href='https://wiki.jenkins-ci.org/display/JENKINS/Violation+Comments+to+GitHub+Plugin'>Violation Comments to GitHub Plugin</a> for details on how to configure and use this plugin.
+  </p>
+</div>


### PR DESCRIPTION
You may want to squash these up;

- Added some default plugin config for security & DRY (e.g github credentials, though this probably ought to use the jenkins Auth)
- SimpleBuildStep for use & compatibility with workflows
- A bit of hackery as workflow requires @Databoundconstructor for the recorder object

