### PR TITLE
Remove unneeded configuration in buildPlugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,4 @@
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
  
-buildPlugin(
-  findbugs: [
-    run: true, 
-    archive: true,
-    unstableTotalAll: 0
-  ],
-)
+buildPlugin()


### PR DESCRIPTION
Spotbugs reporting is being enabled by default in https://github.com/jenkins-infra/pipeline-library/pull/121, update to parent pom 4.x to use spotbugs instead of findbugs.